### PR TITLE
Fixes for lots of issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,76 @@
 # instiki2git
 
-A script for exporting an Instiki installation to a git repository.
+A tool for exporting an Instiki installation to a git repository.
 
 ## Installation
 
 Run the following in the source directory:
-
-    $ pip install .
+```shell
+$ pip install .
+```
 
 ## Configuration
 
-Place a configuration file at ~/.instiki2git which has the following format:
-
-    # ~/.instiki2git
-    [web]
-    id = 1
-
-    [repository]
-    path = /home/nlab/nlab-content.git
-
-    [database]
-    host = localhost
-    db = nlab
-    user = nlab
-    password = xxx
-    charset = utf8
+Via command-line options.
 
 ## Usage
 
-Run the following:
+See:
+```shell
+$ instiki2git --help
+```
 
-    $ instiki2git
+## Details
 
-Optionally you can specify the `--config-file` (`~/.instiki2git` by default) or
-`--latest-revision-file` (`/tmp/instiki2git` by default) parameters.
+### Revision ordering
+
+Commits are ordered by database update time (as encoded by the field `updated_at` in the revisions table), with ties decided by revision id.
+This is the only ordering that makes sense for a tool that runs repeatedly and whose overall output should not depend on when exactly it is run.
+In contrast, revisions in instiki are ordered by the field `revised_at` (revision time).
+For this reason, we record the revision time in each revision commit as the author time.
+
+This has several consequences:
+
+* We may miss updates of the same revision if are sent to the database within the same second.
+  This can happen if two people save a page update using the previous author name at similar times.
+  It can also happen if someone edits a page in quick succession.
+
+* Revisions may be committed in a different order in the source backup repository than shown on the history page of Instiki.
+  In particular, the pre-2015 revisions in the nLab database all have similar `updated_at` fields that are unrelated to the actual revision time.
+
+### Metadata encoding
+
+We store revision metadata in the git commit information.
+Depending on where we store something, we use a percent encoding for reserved characters.
+
+* The author name of a git commit has reserved characters `\0`, `\n`, `<`, `>`.
+  We use it to store revision author names.
+
+* Commit messages are lines of the form "<key>: <value>" with `\0` and `\n` reserved in key and value and additionally `:` reserved in the key.
+
+## Tutorial
+
+Create and move to an empty directory.
+Initialize a git repository and make an initial commit:
+
+```shell
+$ git init
+$ git commit --allow-empty -m 'Initial commit.'
+```
+Set up a default push remote for the default branch.
+Run instiki2git in this directory:
+``` shell
+$ instiki2git -v --unix-socket [...] --web-id 1 --push --partition-sizes 1 1 1 1
+```
+This will record the Instiki revisions of the given web in the repository.
+
+To update, just rerun the same instiki2git command.
+
+There is an option `--html` for HTML instead of source backup.
+Currently, you have to use different repositories for the two.
 
 ## Acknowledgment
 
-This script was coded jointly with [@sajeel](https://sajeelk.github.io/).
+This script was coded by Adeel and [Sajeel](https://sajeelk.github.io/) Khan.
+It was improved by Felix Wellen.
+It was rewritten by Christian Sattler.

--- a/percent_code.py
+++ b/percent_code.py
@@ -39,3 +39,6 @@ class PercentCode:
 
 # These are the reserved bytes in git commit authors and committers.
 git_identity = PercentCode(reserved = map(ord, ['\0', '\n', '<', '>']))
+
+# These are the reserved bytes in our commit metadata values.
+commit_data = PercentCode(reserved = map(ord, ['\0', '\n']))

--- a/percent_code.py
+++ b/percent_code.py
@@ -40,5 +40,6 @@ class PercentCode:
 # These are the reserved bytes in git commit authors and committers.
 git_identity = PercentCode(reserved = map(ord, ['\0', '\n', '<', '>']))
 
-# These are the reserved bytes in our commit metadata values.
-commit_data = PercentCode(reserved = map(ord, ['\0', '\n']))
+# These are the reserved bytes in our commit metadata.
+commit_data_key = PercentCode(reserved = map(ord, ['\0', '\n', ':']))
+commit_data_value = PercentCode(reserved = map(ord, ['\0', '\n']))

--- a/percent_code.py
+++ b/percent_code.py
@@ -1,0 +1,41 @@
+from collections.abc import Iterable
+
+class PercentCode:
+    '''Percent coding operating on bytes.'''
+
+    def __init__(self, *, special : int = ord('%'), reserved: Iterable[int] = []):
+        self.special = special
+        self.to_encode = frozenset([special] + list(reserved))
+
+    def decode_iterable(self, jt: Iterable[int]) -> Iterable[int]:
+        jt = iter(jt)
+        while True:
+            try:
+                b = next(jt)
+            except StopIteration:
+                return
+            if b == self.special:
+                c1 = next(jt) - 0x30
+                c0 = next(jt) - 0x30
+                yield 0x10 * c1 + c0
+            else:
+                yield b
+
+    def encode_iterable(self, it: Iterable[int]) -> Iterable[int]:
+        for x in it:
+            if x in self.to_encode:
+                (c1, c0) = divmod(x, 16)
+                yield self.special
+                yield c1 + 0x30
+                yield c0 + 0x30
+            else:
+                yield x
+
+    def decode(self, xs: Iterable[int]) -> bytes:
+        return bytes(self.decode_iterable(xs))
+
+    def encode(self, xs: Iterable[int]) -> bytes:
+        return bytes(self.encode_iterable(xs))
+
+# These are the reserved bytes in git commit authors and committers.
+git_identity = PercentCode(reserved = map(ord, ['\0', '\n', '<', '>']))

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ ignore =
     E305,
 
     ## Too many false positives.
-    
+
     # Whitespace after '#' before textual comment.
     # Don't want to have this whitespace for commented out code.
     E265,

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,37 @@ install_requires =
 console_scripts =
     instiki2git = instiki2git.cli:cli
     instiki2git-html = instiki2git.cli:cli_html
+
+[flake8]
+ignore =
+    ## Not convinced at all.
+
+    # Whitespace around assignment symbol for keyword arguments.
+    # Expression on the right can contain whitespaces,
+    # so whitespace around assignment symbol should be the default.
+    E251,
+
+    ## Not convinced in all cases.
+
+    # For assert-like negated if-statements, our pattern is to have "not" at the top-level:
+    # > if not <assert condition>:
+    # >     raise <error>
+    # This should be used also if <assert condition> is "<item> in <collection>".
+    # But E713 would force "if <item> not in <collection>", contrary to the above pattern.
+    # Similarly for E714 with "is not".
+    E713,
+    E714,
+
+    # This enforces two blank lines between top-level function and class definitions.
+    # This makes sense for modules with big classes or long, nested functions.
+    # But it does not make sense for utility modules with lots of related small top-level functions.
+    # It is also a problem with function definitions that have some related assignments before them.
+    E302,
+    E305,
+
+    ## Too many false positives.
+    
+    # Whitespace after '#' before textual comment.
+    # Don't want to have this whitespace for commented out code.
+    E265,
+max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ author = adeel
 author_email = adeel@yusufzai.me
 
 [options]
+packages = instiki2git
 package_dir =
     instiki2git = src
 python_requires = ~=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ install_requires =
 [options.entry_points]
 console_scripts =
     instiki2git = instiki2git.cli:cli
-    instiki2git-html = instiki2git.cli:cli_html
 
 [flake8]
 ignore =

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,7 @@ python_requires = ~=3.9
 install_requires =
     PyMySQL
     dulwich
-    click
     requests
-    configparser
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,9 @@
 [metadata]
 name = instiki2git
-version = 0.1
+version = 0.2
 description = A tool for exporting an Instiki installation to a git repository.
 license = MIT
-author = adeel
-author_email = adeel@yusufzai.me
+author = The nLab technical team
 
 [options]
 packages = instiki2git

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 import pymysql.cursors
 import requests
-from typing import Any, Iterable, NoReturn, Optional, Tuple
+from typing import Any, Iterable, NoReturn, Optional, Tuple, Union
 
 from instiki2git.percent_code import PercentCode
 
@@ -87,7 +87,7 @@ def get_commit(repo: dulwich.repo.Repo, id: bytes) -> dulwich.repo.Commit:
         raise TypeError('does not refer to a commit: {sha.decode()}')
     return obj
 
-def git_add_file(repo: dulwich.repo.Repo, path: Path, content: bytes | str) -> NoReturn:
+def git_add_file(repo: dulwich.repo.Repo, path: Path, content: Union[bytes, str]) -> NoReturn:
     """
     Create a file in the given repository and stage it.
     This creates all needed parent directories.

--- a/src/cli.py
+++ b/src/cli.py
@@ -204,6 +204,9 @@ def load_commit_and_push(
         Back up rendered HTML pages instead of sources.
         Note: do note mix source and html repositories.
     """
+    logger.debug('Resetting index.')
+    repo.reset_index()
+
     pos = get_current_position(repo)
     logger.info(f'Current revision position: {pos}.')
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -207,7 +207,7 @@ def load_and_commit_new_revisions(
   # So sad (for multiple reasons).
   query = f'''\
 select r.*, p.* \
-from revisions idx force index(quad) \
+from revisions idx force index(index_revisions_on_web_id_and_revised_at_and_id_and_page_id) \
 join revisions r on r.id = idx.id \
 join pages p on p.id = idx.page_id \
 where idx.web_id = %s\

--- a/src/cli.py
+++ b/src/cli.py
@@ -26,13 +26,13 @@ def get_db_conn(**kwargs):
     use_unicode = True,
   )
 
-def query_iterator(cursor, query: str, params: Iterable[Any] = None):
+def query_iterator(cursor: pymysql.cursors.Cursor, query: str, params: Iterable[Any] = None) -> Iterable[dict[str, Any]]:
   logger.debug(f'Query: {query}')
   if params:
     params = tuple(params)
     logger.debug(f'Query parameters: {params}')
   cursor.execute(query, params)
-  return cursor.fetchall()
+  return iter(cursor)
 
 def load_new_revisions_by_time(db_config, web_id, latest_revision_time=None):
   """
@@ -180,7 +180,7 @@ def get_current_position(repo: dulwich.repo.Repo) -> Optional[Tuple[datetime, in
 
 def load_and_commit_new_revisions(
     repo: dulwich.repo.Repo,
-    cursor,
+    cursor: pymysql.cursors.Cursor,
     web_id: int,
     horizon: Optional[datetime] = None,
     include_ip: bool = False,

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,5 +1,6 @@
 import os,errno
-import time, datetime
+import time
+import datetime
 import configparser
 import pymysql.cursors
 import dulwich.repo
@@ -153,10 +154,13 @@ def commit_revision_to_repo(repo: dulwich.repo.Repo, rev: dict):
   def with_empty_email(xs):
     return xs + b' <>'
 
+  # We assume datetime fields in the database use UTC.
+  revision_date = rev['revised_at'].replace(tzinfo = datetime.timezone.utc)
+
   repo.do_commit(
     message = commit_message_encode({
       'Revision ID': str(rev['id']),
-      'Revision date': str(rev['revised_at']),
+      'Revision date': str(revision_date),
       'Page name': rev['name'],
       'Author': rev['author'],
       'IP address': rev['ip'],
@@ -165,6 +169,8 @@ def commit_revision_to_repo(repo: dulwich.repo.Repo, rev: dict):
     author = with_empty_email(
       git_identity_code.encode(rev['author'].encode('utf8'))
     ),
+    author_timestamp = revision_date.timestamp(),
+    author_timezone = 0,
   )
 
 def read_latest_revision_id(latest_revision_file):

--- a/src/cli.py
+++ b/src/cli.py
@@ -142,9 +142,7 @@ def commit_revision(repo: dulwich.repo.Repo, revision: dict):
   repo.do_commit(
     message = commit_message_encode({
       'Revision ID': str(revision['id']),
-      'Revision date': str(revision_date),
       'Page name': revision['name'],
-      'Author': revision['author'],
       'IP address': revision['ip'],
     }),
     committer = with_empty_email(b'instiki2git'),

--- a/src/cli.py
+++ b/src/cli.py
@@ -298,13 +298,14 @@ def cli() -> NoReturn:
         add_help = False,
     )
     parser.add_argument('--repo', type = Path, metavar = 'DIR', default = Path(), help = '''
-defaults to working directory
+Defaults to working directory.
 ''')
-    parser.add_argument('--web-id', type = int, metavar = 'ID', required = True, help = 'ID of the web to back up')
-    parser.add_argument('--html', action = 'store_true', help = 'back up html instead of source')
+    parser.add_argument('--web-id', type = int, metavar = 'ID', required = True, help = 'ID of the web to back up.')
+    parser.add_argument('--html', action = 'store_true', help = 'Back up HTML instead of source.')
+
+    g = parser.add_argument_group(title = 'source backup options')
     parser.add_argument('--include-ip', action = 'store_true', help = '''
 Include author IP in the commit message for each revision.
-Source mode only.
 ''')
 
     g = parser.add_argument_group(title = 'HTML backup options')
@@ -316,7 +317,7 @@ Defaults to http://localhost.
 
     g = parser.add_argument_group(title = 'horizon options')
     g.add_argument('--safety-interval', type = int, metavar = 'SECONDS', default = 300, help = '''
-Only consider revisions older than the given time interval (default: 300s).
+Only consider revisions updated more than the given time interval in the past (default: 300s).
 This helps prevent missing revisions that arrive out of order in the database or have identical revision time.
 ''')
     g.add_argument('--horizon', type = int, help = '''
@@ -327,10 +328,10 @@ This helps prevent missing revisions that arrive out of order in the database or
     g = parser.add_argument_group(title = 'database connection')
     g.add_argument('--host', type = str)
     g.add_argument('--port', type = int)
-    g.add_argument('--unix_socket', type = Path, metavar = 'PATH', help = 'alternative to host and port')
-    g.add_argument('--user', type = str, help = 'not needed when authenticating via Unix domain socket')
+    g.add_argument('--unix-socket', type = Path, metavar = 'PATH', help = 'Alternative to host and port.')
+    g.add_argument('--user', type = str, help = 'Not needed when authenticating via Unix domain socket.')
     g.add_argument('--password', type = str)
-    g.add_argument('--database', type = str, required = True, help = 'required')
+    g.add_argument('--database', type = str, required = True, help = 'Required.')
 
     g = parser.add_argument_group(title = 'help and debugging')
     g.add_argument('-h', '--help', action = 'help', help = 'Show this help message and exit.')
@@ -362,7 +363,7 @@ Print informational (specify once) or debug (specify twice) messages on stderr.
     connection: pymysql.Connection = pymysql.connect(
         host = args.host,
         port = args.port,
-        unix_socket = args.unix_socket,
+        unix_socket = None if args.unix_socket is None else bytes(args.unix_socket),
         user = args.user,
         password = args.password,
         database = args.database,

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,17 +1,14 @@
-import os,errno
+import os
 import time
 from datetime import datetime, timedelta, timezone
-import configparser
 import pymysql.cursors
 import dulwich.repo
 import dulwich.porcelain
 import argparse
 import requests
-import re
 from pathlib import Path
 from typing import Any, Iterable, NoReturn, Optional, Tuple
 import logging
-import sys
 
 from instiki2git.percent_code import PercentCode
 
@@ -19,335 +16,331 @@ from instiki2git.percent_code import PercentCode
 logger = logging.getLogger(__name__)
 
 def get_db_conn(**kwargs):
-  return pymysql.connect(
-    **kwargs,
-    cursorclass=pymysql.cursors.SSDictCursor,
-    charset = 'utf8',
-    use_unicode = True,
-  )
+    return pymysql.connect(
+        **kwargs,
+        cursorclass=pymysql.cursors.SSDictCursor,
+        charset = 'utf8',
+        use_unicode = True,
+    )
 
 def query_iterator(cursor: pymysql.cursors.Cursor, query: str, params: Iterable[Any] = None) -> Iterable[dict[str, Any]]:
-  logger.debug(f'Query: {query}')
-  if params:
-    params = tuple(params)
-    logger.debug(f'Query parameters: {params}')
-  cursor.execute(query, params)
-  return iter(cursor)
+    logger.debug(f'Query: {query}')
+    if params:
+        params = tuple(params)
+        logger.debug(f'Query parameters: {params}')
+    cursor.execute(query, params)
+    return iter(cursor)
 
 def load_new_revisions_by_time(cursor, web_id, latest_revision_time=None):
-  """
-  Load all revisions, using the given database configuration to connect.  If a
-  `latest_revision_time` is provided, only loads revisions committed after that.
-  """
-  date_selector = ""
-  if latest_revision_time:
-    time = latest_revision_time.strftime('%Y-%m-%d %H:%M:%S')
-    date_selector = " AND r.updated_at >= '%s'" % time
-  query = ("SELECT r.id,r.page_id,r.author,r.ip,r.revised_at,r.content,p.name"
-    " FROM revisions r INNER JOIN pages p ON (r.page_id=p.id)"
-    " WHERE r.web_id=%s%s"
-    " ORDER BY r.id") % (web_id, date_selector)
-  cursor.execute(query)
-  return cursor.fetchall()
+    """
+    Load all revisions, using the given database configuration to connect.    If a
+    `latest_revision_time` is provided, only loads revisions committed after that.
+    """
+    date_selector = ""
+    if latest_revision_time:
+        time = latest_revision_time.strftime('%Y-%m-%d %H:%M:%S')
+        date_selector = " AND r.updated_at >= '%s'" % time
+    query = ("SELECT r.id,r.page_id,r.author,r.ip,r.revised_at,r.content,p.name"
+             " FROM revisions r INNER JOIN pages p ON (r.page_id=p.id)"
+             " WHERE r.web_id=%s%s"
+             " ORDER BY r.id") % (web_id, date_selector)
+    cursor.execute(query)
+    return cursor.fetchall()
 
 # Used by the following two functions.
 commit_data_key_code = PercentCode(reserved = map(ord, ['\0', '\n', ':']))
 commit_data_value_code = PercentCode(reserved = map(ord, ['\0', '\n']))
 
 def commit_message_encode(values: dict[str, str]) -> bytes:
-  """Encode metadata in the commit message."""
-  return b''.join(b''.join([
-      commit_data_key_code.encode(key.encode('utf8')),
-      b': ',
-      commit_data_value_code.encode(value.encode('utf8')),
-      b'\n',
-    ]) for (key, value) in values.items()
-  )
+    """Encode metadata in the commit message."""
+    return b''.join(b''.join([
+        commit_data_key_code.encode(key.encode('utf8')),
+        b': ',
+        commit_data_value_code.encode(value.encode('utf8')),
+        b'\n',
+    ]) for (key, value) in values.items())
 
 def commit_message_decode(msg: bytes) -> dict[str, str]:
-  """Decode metadata in the commit message."""
-  def f(line):
-    (key, value) = line.split(b': ', 1)
-    return (
-      commit_data_key_code.decode(key).decode('utf8'),
-      commit_data_value_code.decode(value).decode('utf8'),
-    )
+    """Decode metadata in the commit message."""
+    def f(line):
+        (key, value) = line.split(b': ', 1)
+        return (
+            commit_data_key_code.decode(key).decode('utf8'),
+            commit_data_value_code.decode(value).decode('utf8'),
+        )
 
-  return dict(map(f, msg.splitlines()))
+    return dict(map(f, msg.splitlines()))
 
 def add_file(repo: dulwich.repo.Repo, path: Path, content: bytes | str) -> NoReturn:
-  """
-  Create a file in the given repository and stage it.
-  This creates all needed parent directories.
+    """
+    Create a file in the given repository and stage it.
+    This creates all needed parent directories.
 
-  Note: the given path must be relative to the repository path.
-  """
-  for ancestor in reversed(path.parents):
-    ancestor.mkdir(exist_ok = True)
+    Note: the given path must be relative to the repository path.
+    """
+    for ancestor in reversed(path.parents):
+        ancestor.mkdir(exist_ok = True)
 
-  if isinstance(content, str):
-    path.write_text(content, encoding = 'utf8')
-  else:
-    path.write_bytes(content)
+    if isinstance(content, str):
+        path.write_text(content, encoding = 'utf8')
+    else:
+        path.write_bytes(content)
 
-  repo.stage(path)
+    repo.stage(path)
 
 # These are the reserved bytes in git commit authors and committers.
 git_identity_code = PercentCode(reserved = map(ord, ['\0', '\n', '<', '>']))
 
 def commit_revision(repo: dulwich.repo.Repo, revision: dict, include_ip: bool):
-  """Commit a revision to a git repository."""
-  id = revision['id']
-  logger.info(f'Committing revision {id}.')
+    """Commit a revision to a git repository."""
+    id = revision['id']
+    logger.info(f'Committing revision {id}.')
 
-  path = Path('pages') / str(revision['page_id'])
-  add_file(repo, path / 'content.md', revision['content'])
-  add_file(repo, path / 'name', revision['name'])
+    path = Path('pages') / str(revision['page_id'])
+    add_file(repo, path / 'content.md', revision['content'])
+    add_file(repo, path / 'name', revision['name'])
 
-  # git insists on an email address, so we add an empty one.
-  def with_empty_email(xs):
-    return xs + b' <>'
+    # git insists on an email address, so we add an empty one.
+    def with_empty_email(xs):
+        return xs + b' <>'
 
-  # We assume datetime fields in the database use UTC.
-  revision_date = revision['revised_at'].replace(tzinfo = timezone.utc)
+    # We assume datetime fields in the database use UTC.
+    revision_date = revision['revised_at'].replace(tzinfo = timezone.utc)
 
-  def fields():
-    yield ('Revision ID', str(revision['id']))
-    yield ('Page name', revision['name'])
-    if include_ip:
-      yield ('IP address', revision['ip'])
+    def fields():
+        yield ('Revision ID', str(revision['id']))
+        yield ('Page name', revision['name'])
+        if include_ip:
+            yield ('IP address', revision['ip'])
 
-  repo.do_commit(
-    message = commit_message_encode(dict(fields())),
-    committer = with_empty_email(b'instiki2git'),
-    author = with_empty_email(
-      git_identity_code.encode(revision['author'].encode('utf8'))
-    ),
-    author_timestamp = revision_date.timestamp(),
-    author_timezone = 0,
-  )
+    repo.do_commit(
+        message = commit_message_encode(dict(fields())),
+        committer = with_empty_email(b'instiki2git'),
+        author = with_empty_email(
+            git_identity_code.encode(revision['author'].encode('utf8'))
+        ),
+        author_timestamp = revision_date.timestamp(),
+        author_timezone = 0,
+    )
 
 def get_head(repo: dulwich.repo.Repo) -> Optional[bytes]:
-  try:
-    return repo.head()
-  except KeyError:
-    return None
+    try:
+        return repo.head()
+    except KeyError:
+        return None
 
 def get_commit(repo: dulwich.repo.Repo, sha: bytes) -> dulwich.repo.Commit:
-  x = repo.get_object(sha)
-  if not isinstance(x, dulwich.repo.Commit):
-    raise TypeError('does not refer to a commit: {sha.decode()}')
-  return x
+    x = repo.get_object(sha)
+    if not isinstance(x, dulwich.repo.Commit):
+        raise TypeError('does not refer to a commit: {sha.decode()}')
+    return x
 
 def get_current_position(repo: dulwich.repo.Repo) -> Optional[Tuple[datetime, int]]:
-  """
-  Return the tuple of (revised_at, id) for the revision encoded by the head commit.
-  Returns None if there is no head (e.g. if the repository is empty).
-  """
-  ref = get_head(repo)
-  if ref:
-    commit = get_commit(repo, ref)
-    revision_date = datetime.fromtimestamp(commit.author_time)
-    metadata = commit_message_decode(commit.message)
-    return (revision_date, metadata['Revision ID'])
+    """
+    Return the tuple of (revised_at, id) for the revision encoded by the head commit.
+    Returns None if there is no head (e.g. if the repository is empty).
+    """
+    ref = get_head(repo)
+    if ref:
+        commit = get_commit(repo, ref)
+        revision_date = datetime.fromtimestamp(commit.author_time)
+        metadata = commit_message_decode(commit.message)
+        return (revision_date, metadata['Revision ID'])
 
 def load_and_commit_new_revisions(
-    repo: dulwich.repo.Repo,
-    cursor: pymysql.cursors.Cursor,
-    web_id: int,
-    horizon: Optional[datetime] = None,
-    include_ip: bool = False,
+        repo: dulwich.repo.Repo,
+        cursor: pymysql.cursors.Cursor,
+        web_id: int,
+        horizon: Optional[datetime] = None,
+        include_ip: bool = False,
 ) -> NoReturn:
-  """
-  Arguments:
-  * repo:
-      The repository to modify.
-      Commits are made to the current branch.
-  * web_id: the id of the web from which to load revisions.
-  * cursor:
-      The database connection cursor.
-      Must return a dictionary for each queried row.
-  * horizon:
-      If given, only consider revisions with prior revision time (revised_at).
-      This should be about a minute behind current time.
-      This helps prevent missing revision updates with identical revision time.
-  * include_ip: whether to include the author IP in the commit message for each revision.
-  """
-  pos = get_current_position(repo)
-  logger.info(f'Current revision position: {pos}')
+    """
+    Arguments:
+    * repo:
+            The repository to modify.
+            Commits are made to the current branch.
+    * web_id: the id of the web from which to load revisions.
+    * cursor:
+            The database connection cursor.
+            Must return a dictionary for each queried row.
+    * horizon:
+            If given, only consider revisions with prior revision time (revised_at).
+            This should be about a minute behind current time.
+            This helps prevent missing revision updates with identical revision time.
+    * include_ip: whether to include the author IP in the commit message for each revision.
+    """
+    pos = get_current_position(repo)
+    logger.info(f'Current revision position: {pos}')
 
-  # So sad (for multiple reasons).
-  query = f'''\
+    # So sad (for multiple reasons).
+    query = '''\
 select r.*, p.* \
 from revisions idx force index(index_revisions_on_web_id_and_revised_at_and_id_and_page_id) \
 join revisions r on r.id = idx.id \
 join pages p on p.id = idx.page_id \
 where idx.web_id = %s\
 '''
-  params = [web_id]
-  if pos:
-    query += ' and (idx.revised_at, idx.id) > (%s, %s)'
-    params.extend(pos)
-  if horizon:
-    query += ' and idx.revised_at < %s'
-    params.append(horizon)
+    params = [web_id]
+    if pos:
+        query += ' and (idx.revised_at, idx.id) > (%s, %s)'
+        params.extend(pos)
+    if horizon:
+        query += ' and idx.revised_at < %s'
+        params.append(horizon)
 
-  horizon_msg = f'before {horizon} ' if horizon else ''
-  logger.info(f'Loading revisions {horizon_msg}from database.')
-  for revision in query_iterator(cursor, query, params):
-    commit_revision(repo, revision, include_ip)
+    horizon_msg = f'before {horizon} ' if horizon else ''
+    logger.info(f'Loading revisions {horizon_msg}from database.')
+    for revision in query_iterator(cursor, query, params):
+        commit_revision(repo, revision, include_ip)
 
 # begin html repository functions
 
 def read_latest_download_file(latest_download_file):
-  try:
-    datetime.fromtimestamp(latest_download_file.read_text())
-  except FileNotFoundError:
-    return 0
+    try:
+        datetime.fromtimestamp(latest_download_file.read_text())
+    except FileNotFoundError:
+        return 0
 
 def write_latest_download_file(latest_download_file):
-  latest_download_file.write_text(str(time.time()))
+    latest_download_file.write_text(str(time.time()))
 
 def download_html_page(page_id, html_repo_path, web_http_url):
-  r = requests.get("%s/show_by_id/%s" % (web_http_url, page_id))
-  page_path = html_repo_path / 'pages' / f'{page_id}.html'
-  page_path.write_bytes(r.content)
+    r = requests.get("%s/show_by_id/%s" % (web_http_url, page_id))
+    page_path = html_repo_path / 'pages' / f'{page_id}.html'
+    page_path.write_bytes(r.content)
 
-def download_and_stage_html_pages(pages_list, html_repo, html_repo_path,
-  web_http_url):
-  for p in pages_list:
-    download_html_page(p, html_repo_path, web_http_url)
-  html_repo.stage(map(lambda p: "pages/%d.html" % p, pages_list))
+def download_and_stage_html_pages(pages_list, html_repo, html_repo_path, web_http_url):
+    for p in pages_list:
+        download_html_page(p, html_repo_path, web_http_url)
+    html_repo.stage(map(lambda p: "pages/%d.html" % p, pages_list))
 
-def html_repo_populate(repo_path, html_repo_path, web_http_url,
-  latest_download_file):
-  """
-  This is meant to be used in case the usual repository is already set up, and
-  but the html repository is not.  It will download the latest html version of
-  each page and save them all to the html repository as one commit.  It will
-  ignore pages that already have html versions downloaded.
-  """
-  write_latest_download_file(latest_download_file)
-  pages_list = map(lambda f: f[:-3],
-                   filter(lambda f: (f.endswith(".md") and
-                            not os.path.isfile(
-                              os.path.join(html_repo_path, "pages",
-                                           "%s.html" % f[:-3]))),
-                          os.listdir(os.path.join(repo_path, "pages"))))
-  html_repo = dulwich.repo.Repo(html_repo_path)
-  download_and_stage_html_pages(pages_list, html_repo, html_repo_path,
-    web_http_url)
-  html_repo.do_commit("Added current html versions.",
-    "instiki2git <>")
-
-def html_repo_update(html_repo_path, cursor, web_id, web_http_url,
-  latest_download_file):
-  latest_download_time = read_latest_download_file(latest_download_file)
-  write_latest_download_file(latest_download_file)
-  revs = load_new_revisions_by_time(cursor, web_id, latest_download_time)
-  pages_list = {r["page_id"] for r in revs}
-  if pages_list:
+def html_repo_populate(repo_path, html_repo_path, web_http_url, latest_download_file):
+    """
+    This is meant to be used in case the usual repository is already set up, and
+    but the html repository is not.    It will download the latest html version of
+    each page and save them all to the html repository as one commit.    It will
+    ignore pages that already have html versions downloaded.
+    """
+    write_latest_download_file(latest_download_file)
+    pages_list = map(lambda f: f[:-3], filter(
+        lambda f: (f.endswith(".md") and not os.path.isfile(os.path.join(html_repo_path, "pages", "%s.html" % f[:-3]))),
+        os.listdir(os.path.join(repo_path, "pages")),
+    ))
     html_repo = dulwich.repo.Repo(html_repo_path)
-    download_and_stage_html_pages(pages_list, html_repo, html_repo_path,
-      web_http_url)
-    html_repo.do_commit("Updated %d pages." % len(pages_list),
-      "instiki2git <>")
+    download_and_stage_html_pages(pages_list, html_repo, html_repo_path, web_http_url)
+    html_repo.do_commit("Added current html versions.", "instiki2git <>")
+
+def html_repo_update(html_repo_path, cursor, web_id, web_http_url, latest_download_file):
+    latest_download_time = read_latest_download_file(latest_download_file)
+    write_latest_download_file(latest_download_file)
+    revs = load_new_revisions_by_time(cursor, web_id, latest_download_time)
+    pages_list = {r["page_id"] for r in revs}
+    if pages_list:
+        html_repo = dulwich.repo.Repo(html_repo_path)
+        download_and_stage_html_pages(pages_list, html_repo, html_repo_path, web_http_url)
+        html_repo.do_commit("Updated %d pages." % len(pages_list), "instiki2git <>")
 
 # end html repository functions
 
-
 def cli():
-  parser = argparse.ArgumentParser(
-    description = 'A tool for exporting an Instiki installation to a git repository.',
-    add_help = False,
-  )
-  parser.add_argument('--web-id', type = int, metavar = 'ID', required = True, help = 'ID of the web to back up')
-  parser.add_argument('--html', action = 'store_true', help = 'back up html instead of source')
-  parser.add_argument('--include-ip', action = 'store_true', help = 'include author IP in commit message for revisions')
+    parser = argparse.ArgumentParser(
+        description = 'A tool for exporting an Instiki installation to a git repository.',
+        add_help = False,
+    )
+    parser.add_argument('--web-id', type = int, metavar = 'ID', required = True, help = 'ID of the web to back up')
+    parser.add_argument('--html', action = 'store_true', help = 'back up html instead of source')
+    parser.add_argument('--include-ip', action = 'store_true', help = '''
+include author IP in commit message for revisions
+''')
 
-  g = parser.add_argument_group(title = 'HTML backup options')
-  g.add_argument('--populate', action = 'store_true', help = '''
+    g = parser.add_argument_group(title = 'HTML backup options')
+    g.add_argument('--populate', action = 'store_true', help = '''
 Populate HTML repository instead of updating it.
 This uses the source repository.
 ''')
-  g.add_argument('--repo-html', type = Path, metavar = 'DIR')
-  g.add_argument('--latest-download-file', metavar = 'FILE', type = Path, help = '''
+    g.add_argument('--repo-html', type = Path, metavar = 'DIR')
+    g.add_argument('--latest-download-file', metavar = 'FILE', type = Path, help = '''
 File containing the time of the last HTML download.
 ''')
-  g.add_argument('--http-url', type = str, metavar = 'URL', help = '''
+    g.add_argument('--http-url', type = str, metavar = 'URL', help = '''
 URL prefix to use for html backup.
 Example: https://ncatlab.org/nlab
 ''')
 
-  g = parser.add_argument_group(title = 'horizon options')
-  g.add_argument('--safety-interval', type = int, metavar = 'SECONDS', default = 300, help = '''
+    g = parser.add_argument_group(title = 'horizon options')
+    g.add_argument('--safety-interval', type = int, metavar = 'SECONDS', default = 300, help = '''
 Only consider revisions older than the given time interval (default: 300s).
 This helps prevent missing revisions that arrive out of order in the database or have identical revision time.
 ''')
-  g.add_argument('--horizon', type = int, help = '''
-  Only consider revisions older than the given UTC timestamp.
-  Overrides `--safety-interval`.
+    g.add_argument('--horizon', type = int, help = '''
+    Only consider revisions older than the given UTC timestamp.
+    Overrides `--safety-interval`.
 ''')
 
-  g = parser.add_argument_group(title = 'repository options')
-  g.add_argument('--repo', type = Path, metavar = 'DIR', required = True, help = 'required')
-  
-  g = parser.add_argument_group(title = 'database connection')
-  g.add_argument('--host', type = str)
-  g.add_argument('--port', type = int)
-  g.add_argument('--unix_socket', type = Path, metavar = 'PATH', help = 'alternative to host and port')
-  g.add_argument('--user', type = str, help = 'not needed when authenticating via Unix domain socket')
-  g.add_argument('--password', type = str)
-  g.add_argument('--database', type = str, required = True, help = 'required')
+    g = parser.add_argument_group(title = 'repository options')
+    g.add_argument('--repo', type = Path, metavar = 'DIR', required = True, help = 'required')
 
-  g = parser.add_argument_group(title = 'help and debugging')
-  g.add_argument('-h', '--help', action = 'help', help = 'Show this help message and exit.')
-  g.add_argument('-v', '--verbose', action = 'count', default = 0, help = 'Print informational (specify once) or debug  (specify twice) messages on stderr.')
+    g = parser.add_argument_group(title = 'database connection')
+    g.add_argument('--host', type = str)
+    g.add_argument('--port', type = int)
+    g.add_argument('--unix_socket', type = Path, metavar = 'PATH', help = 'alternative to host and port')
+    g.add_argument('--user', type = str, help = 'not needed when authenticating via Unix domain socket')
+    g.add_argument('--password', type = str)
+    g.add_argument('--database', type = str, required = True, help = 'required')
 
-  # Parse arguments.
-  args = parser.parse_args()
+    g = parser.add_argument_group(title = 'help and debugging')
+    g.add_argument('-h', '--help', action = 'help', help = 'Show this help message and exit.')
+    g.add_argument('-v', '--verbose', action = 'count', default = 0, help = '''
+Print informational (specify once) or debug (specify twice) messages on stderr.
+''')
 
-  # Configure logging.
-  logging.basicConfig()
-  logger.setLevel({
-    0: logging.WARNING,
-    1: logging.INFO,
-  }.get(args.verbose, logging.DEBUG))
+    # Parse arguments.
+    args = parser.parse_args()
 
-  # Compute horizon.
-  horizon = datetime.utcfromtimestamp(args.horizon) if not args.horizon is None else datetime.now() - timedelta(minutes = args.safety_interval)
-  logger.debug(f'Horizon: {horizon}')
+    # Configure logging.
+    logging.basicConfig()
+    logger.setLevel({
+        0: logging.WARNING,
+        1: logging.INFO,
+    }.get(args.verbose, logging.DEBUG))
 
-  logger.info('Reading repository.')
-  repo = dulwich.repo.Repo(args.repo)
+    # Compute horizon.
+    horizon = {
+        True: datetime.utcfromtimestamp(args.horizon),
+        False: datetime.now() - timedelta(minutes = args.safety_interval),
+    }[args.horizon is not None]
+    logger.debug(f'Horizon: {horizon}')
 
-  logger.info('Connecting to database.')
-  connection = pymysql.connect(
-    host = args.host,
-    port = args.port,
-    unix_socket = args.unix_socket,
-    user = args.user,
-    password = args.password,
-    database = args.database,
-    cursorclass = pymysql.cursors.SSDictCursor,
-    charset = 'utf8',
-    use_unicode = True,
-  )
-  cursor = connection.cursor()
+    logger.info('Reading repository.')
+    repo = dulwich.repo.Repo(args.repo)
 
-  if not args.html:
-    load_and_commit_new_revisions(
-      repo,
-      cursor,
-      args.web_id,
-      horizon = horizon,
-      include_ip = args.include_ip,
+    logger.info('Connecting to database.')
+    connection = pymysql.connect(
+        host = args.host,
+        port = args.port,
+        unix_socket = args.unix_socket,
+        user = args.user,
+        password = args.password,
+        database = args.database,
+        cursorclass = pymysql.cursors.SSDictCursor,
+        charset = 'utf8',
+        use_unicode = True,
     )
+    cursor = connection.cursor()
 
-    logger.info('Pushing repository.')
-    dulwich.porcelain.push(repo = repo)
-  else:
-    if args.populate:
-      html_repo_populate(args.repo, args.html_repo, args.http_url, args.latest_download_file)
+    if not args.html:
+        load_and_commit_new_revisions(
+            repo,
+            cursor,
+            args.web_id,
+            horizon = horizon,
+            include_ip = args.include_ip,
+        )
+
+        logger.info('Pushing repository.')
+        dulwich.porcelain.push(repo = repo)
     else:
-      html_repo_update(args.html_repo, cursor, args.web_id, args.http_url, args.latest_download_file)
+        if args.populate:
+            html_repo_populate(args.repo, args.html_repo, args.http_url, args.latest_download_file)
+        else:
+            html_repo_update(args.html_repo, cursor, args.web_id, args.http_url, args.latest_download_file)

--- a/src/cli.py
+++ b/src/cli.py
@@ -23,8 +23,8 @@ def get_db_conn(db_config):
                          user=db_config["user"],
                          password=db_config["password"],
                          db=db_config["db"],
-                         charset=db_config["charset"],
                          cursorclass=pymysql.cursors.SSDictCursor,
+                         charset='utf8',
                          use_unicode=True)
 
 def query_iterator(cursor, query: str, params: Iterable[Any] = None):
@@ -291,8 +291,7 @@ def read_config(config_file):
   db_config = {"host": config_parser.get("database", "host"),
     "db": config_parser.get("database", "db"),
     "user": config_parser.get("database", "user"),
-    "password": config_parser.get("database", "password"),
-    "charset": config_parser.get("database", "charset")}
+    "password": config_parser.get("database", "password")}
   web_http_url = config_parser.get("web", "http_url")
   return {
     "repo_path": repo_path,

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,29 +1,29 @@
-import os
-import time
-from datetime import datetime, timedelta, timezone
-import pymysql.cursors
-import dulwich.repo
-import dulwich.porcelain
 import argparse
-import requests
-from pathlib import Path
-from typing import Any, Iterable, NoReturn, Optional, Tuple
+from datetime import datetime, timedelta, timezone
+import dulwich.objects
+import dulwich.repo
 import logging
+from pathlib import Path
+import pymysql.cursors
+import requests
+from typing import Any, Iterable, NoReturn, Optional, Tuple
 
 from instiki2git.percent_code import PercentCode
 
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
-def get_db_conn(**kwargs):
-    return pymysql.connect(
-        **kwargs,
-        cursorclass=pymysql.cursors.SSDictCursor,
-        charset = 'utf8',
-        use_unicode = True,
-    )
+# Database queries
 
-def query_iterator(cursor: pymysql.cursors.Cursor, query: str, params: Iterable[Any] = None) -> Iterable[dict[str, Any]]:
+def query_iterator(
+    cursor: pymysql.cursors.DictCursorMixin,
+    query: str,
+    params: Iterable[dict[str, str]] = None,
+) -> Iterable[dict[str, Any]]:
+    """
+    Run a query and return an iterator of result rows
+    This iterator needs to be exhausted before further queries can be made using the underlying connection.
+    """
     logger.debug(f'Query: {query}')
     if params:
         params = tuple(params)
@@ -31,47 +31,69 @@ def query_iterator(cursor: pymysql.cursors.Cursor, query: str, params: Iterable[
     cursor.execute(query, params)
     return iter(cursor)
 
-def load_new_revisions_by_time(cursor, web_id, latest_revision_time=None):
-    """
-    Load all revisions, using the given database configuration to connect.    If a
-    `latest_revision_time` is provided, only loads revisions committed after that.
-    """
-    date_selector = ""
-    if latest_revision_time:
-        time = latest_revision_time.strftime('%Y-%m-%d %H:%M:%S')
-        date_selector = " AND r.updated_at >= '%s'" % time
-    query = ("SELECT r.id,r.page_id,r.author,r.ip,r.revised_at,r.content,p.name"
-             " FROM revisions r INNER JOIN pages p ON (r.page_id=p.id)"
-             " WHERE r.web_id=%s%s"
-             " ORDER BY r.id") % (web_id, date_selector)
-    cursor.execute(query)
-    return cursor.fetchall()
+def query_singleton(
+    cursor: pymysql.cursors.DictCursorMixin,
+    query: str,
+    params: Iterable[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Run a query with exactly one result row."""
+    [result] = query_iterator(cursor, query, params)
+    return result
+
+# Commit message key-value coding.
 
 # Used by the following two functions.
-commit_data_key_code = PercentCode(reserved = map(ord, ['\0', '\n', ':']))
-commit_data_value_code = PercentCode(reserved = map(ord, ['\0', '\n']))
+commit_msg_key_code = PercentCode(reserved = map(ord, ['\0', '\n', ':']))
+commit_msg_value_code = PercentCode(reserved = map(ord, ['\0', '\n']))
 
 def commit_message_encode(values: dict[str, str]) -> bytes:
     """Encode metadata in the commit message."""
     return b''.join(b''.join([
-        commit_data_key_code.encode(key.encode('utf8')),
+        commit_msg_key_code.encode(key.encode('utf8')),
         b': ',
-        commit_data_value_code.encode(value.encode('utf8')),
+        commit_msg_value_code.encode(value.encode('utf8')),
         b'\n',
     ]) for (key, value) in values.items())
 
 def commit_message_decode(msg: bytes) -> dict[str, str]:
     """Decode metadata in the commit message."""
     def f(line):
+        key: str
+        value: str
         (key, value) = line.split(b': ', 1)
         return (
-            commit_data_key_code.decode(key).decode('utf8'),
-            commit_data_value_code.decode(value).decode('utf8'),
+            commit_msg_key_code.decode(key).decode('utf8'),
+            commit_msg_value_code.decode(value).decode('utf8'),
         )
 
     return dict(map(f, msg.splitlines()))
 
-def add_file(repo: dulwich.repo.Repo, path: Path, content: bytes | str) -> NoReturn:
+Position = Tuple[datetime, int]
+Position.__doc__ = """Positions represent a total ordering of revisions in time."""
+
+def commit_values_position_encode(position: Position) -> Iterable[Tuple[str, str]]:
+    (update_date, id) = position
+    yield ('Revision ID', str(id))
+    yield ('Update date', str(update_date))
+
+def commit_values_position_decode(values: dict[str, str]) -> Position:
+    return (datetime.fromisoformat(values['Update date']), int(values['Revision ID']))
+
+# git functions.
+
+def get_head(repo: dulwich.repo.Repo) -> Optional[bytes]:
+    try:
+        return repo.head()
+    except KeyError:
+        return None
+
+def get_commit(repo: dulwich.repo.Repo, sha: bytes) -> dulwich.repo.Commit:
+    sha_file: dulwich.objects.ShaFile = repo.get_object(sha)
+    if not isinstance(sha_file, dulwich.repo.Commit):
+        raise TypeError('does not refer to a commit: {sha.decode()}')
+    return sha_file
+
+def git_add_file(repo: dulwich.repo.Repo, path: Path, content: bytes | str) -> NoReturn:
     """
     Create a file in the given repository and stage it.
     This creates all needed parent directories.
@@ -91,91 +113,116 @@ def add_file(repo: dulwich.repo.Repo, path: Path, content: bytes | str) -> NoRet
 # These are the reserved bytes in git commit authors and committers.
 git_identity_code = PercentCode(reserved = map(ord, ['\0', '\n', '<', '>']))
 
-def commit_revision(repo: dulwich.repo.Repo, revision: dict, include_ip: bool):
-    """Commit a revision to a git repository."""
-    id = revision['id']
-    logger.info(f'Committing revision {id}.')
+def git_identity_with_empty_email(name: bytes) -> bytes:
+    """Format a git user identity without an email address."""
+    return name + b' <>'
 
-    path = Path('pages') / str(revision['page_id'])
-    add_file(repo, path / 'content.md', revision['content'])
-    add_file(repo, path / 'name', revision['name'])
+git_script_identity: bytes = git_identity_with_empty_email(b'instiki2git')
 
-    # git insists on an email address, so we add an empty one.
-    def with_empty_email(xs):
-        return xs + b' <>'
-
-    # We assume datetime fields in the database use UTC.
-    revision_date = revision['revised_at'].replace(tzinfo = timezone.utc)
-    update_date = revision['updated_at'].replace(tzinfo = timezone.utc)
-
-    def fields():
-        yield ('Revision ID', str(id))
-        yield ('Update date', str(update_date))
-        yield ('Page name', revision['name'])
-        if include_ip:
-            yield ('IP address', revision['ip'])
-
+def git_commit(
+    repo: dulwich.repo.Repo,
+    commit_values: Iterable[Tuple[str, str]],
+    author: str = None,
+    author_time: datetime = None,
+) -> NoReturn:
+    """
+    Perform a commit.
+    The message is formed by encoding the given commit values.
+    An optional author (without email) can be given.
+    """
     repo.do_commit(
-        message = commit_message_encode(dict(fields())),
-        committer = with_empty_email(b'instiki2git'),
-        author = with_empty_email(
-            git_identity_code.encode(revision['author'].encode('utf8'))
+        message = commit_message_encode(dict(commit_values)),
+        committer = git_script_identity,
+        author = None if author is None else git_identity_with_empty_email(
+            git_identity_code.encode(author.encode('utf8'))
         ),
-        author_timestamp = revision_date.timestamp(),
-        author_timezone = 0,
+        author_timestamp = None if author_time is None else author_time.timestamp(),
     )
 
-def get_head(repo: dulwich.repo.Repo) -> Optional[bytes]:
-    try:
-        return repo.head()
-    except KeyError:
-        return None
-
-def get_commit(repo: dulwich.repo.Repo, sha: bytes) -> dulwich.repo.Commit:
-    x = repo.get_object(sha)
-    if not isinstance(x, dulwich.repo.Commit):
-        raise TypeError('does not refer to a commit: {sha.decode()}')
-    return x
-
-def get_current_position(repo: dulwich.repo.Repo) -> Optional[Tuple[datetime, int]]:
+def get_current_position(repo: dulwich.repo.Repo) -> Optional[Position]:
     """
     Return the tuple of (updated_at, id) for the revision encoded by the head commit.
     Returns None if there is no head (e.g. if the repository is empty).
     """
-    ref = get_head(repo)
+    ref: bytes = get_head(repo)
     if ref:
-        commit = get_commit(repo, ref)
-        metadata = commit_message_decode(commit.message)
-        return (metadata['Update date'], metadata['Revision ID'])
+        commit: dulwich.objects.Commit = get_commit(repo, ref)
+        commit_values: dict[str, str] = commit_message_decode(commit.message)
+        return commit_values_position_decode(commit_values)
 
-def load_and_commit_new_revisions(
-        repo: dulwich.repo.Repo,
-        cursor: pymysql.cursors.Cursor,
-        web_id: int,
-        horizon: Optional[datetime] = None,
-        include_ip: bool = False,
+# Revision functions.
+
+def revision_datetime(revision: dict[str, Any], field: str) -> datetime:
+    """
+    Extract an aware (UTC) datetime object from a given field in the revision.
+    We assume datetime fields in the database use UTC.
+    """
+    return revision[field].replace(tzinfo = timezone.utc)
+
+def revision_position(revision: dict[str, Any]) -> Position:
+    return (revision_datetime(revision, 'updated_at'), revision['id'])
+
+# Other helper functions.
+
+def get_web_address(cursor: pymysql.cursors.DictCursorMixin, web_id: int) -> str:
+    return query_singleton(cursor, 'select address from webs where id = %s', (web_id,))['address']
+
+def download_page(url: str) -> bytes:
+    logger.debug(f'Loading {url}.')
+    return requests.get(url).content
+
+# Main work function.
+def load_commit_and_push(
+    repo: dulwich.repo.Repo,
+    cursor: pymysql.cursors.DictCursorMixin,
+    web_id: int,
+    horizon: Optional[datetime] = None,
+    include_ip: bool = False,
+    http_url: str = None,
+    html_mode: bool = False,
 ) -> NoReturn:
     """
     Arguments:
     * repo:
-            The repository to modify.
-            Commits are made to the current branch.
+        The repository to modify.
+        Commits are made to the current branch.
     * web_id: the id of the web from which to load revisions.
     * cursor:
-            The database connection cursor.
-            Must return a dictionary for each queried row.
+        The database connection cursor.
+        Must return a dictionary for each queried row.
     * horizon:
-            If given, only consider revisions with prior update time (updated_at).
-            This should be about a minute behind current time.
-            This helps prevent missing revision updates with identical revision time.
-    * include_ip: whether to include the author IP in the commit message for each revision.
+        If given, only consider revisions with prior update time (updated_at).
+        This should be about a minute behind current time.
+        This helps prevent missing revision updates with identical revision time.
+    * include_ip:
+        Whether to include the author IP in the commit message for each revision.
+        Only used in source mode.
+    * http_url:
+        URL prefix to use for html backup.
+        Only used in HTML mode.
+    * html_mode:
+        Back up rendered HTML pages instead of sources.
+        Note: do note mix source and html repositories.
     """
     pos = get_current_position(repo)
-    logger.info(f'Current revision position: {pos}')
+    logger.info(f'Current revision position: {pos}.')
 
-    # So sad (for multiple reasons).
-    query = '''\
-select r.*, p.* \
+    time_before_query = datetime.now(timezone.utc)
+    logger.debug(f'Time before query: {time_before_query}.')
+
+    horizon_msg = f'before {horizon} ' if horizon else ''
+    logger.info(f'Loading revisions {horizon_msg}from database.')
+
+    if not html_mode:
+        fields = 'r.*, p.*'
+    else:
+        # Exclude r.content.
+        # Not needed and main source of space consumption.
+        fields = 'r.id, r.updated_at, r.page_id, p.*'
+
+    # SQL printing, so sad.
+    query = f'''\
+select {fields} \
 from revisions idx force index(index_revisions_on_web_id_and_updated_at_and_id_and_page_id) \
 join revisions r on r.id = idx.id \
 join pages p on p.id = idx.page_id \
@@ -189,84 +236,78 @@ where idx.web_id = %s\
         query += ' and idx.updated_at < %s'
         params.append(horizon)
     query += ' order by idx.updated_at, idx.id'
+    revisions = query_iterator(cursor, query, params)
 
-    horizon_msg = f'before {horizon} ' if horizon else ''
-    logger.info(f'Loading revisions {horizon_msg}from database.')
-    for revision in query_iterator(cursor, query, params):
-        commit_revision(repo, revision, include_ip)
+    updated = False
+    if not html_mode:
+        for revision in revisions:
+            updated = True
+            id = revision['id']
+            logger.info(f'Committing revision {id}.')
 
-# begin html repository functions
+            for (filename, content) in [
+                ('content.md', revision['content']),
+                ('name', revision['name'])
+            ]:
+                git_add_file(repo, Path('pages') / str(revision['page_id']) / filename, content)
 
-def read_latest_download_file(latest_download_file):
-    try:
-        datetime.fromtimestamp(latest_download_file.read_text())
-    except FileNotFoundError:
-        return 0
+            def commit_values():
+                yield from commit_values_position_encode(revision_position(revision))
+                yield ('Page name', revision['name'])
+                if include_ip:
+                    yield ('IP address', revision['ip'])
 
-def write_latest_download_file(latest_download_file):
-    latest_download_file.write_text(str(time.time()))
+            git_commit(repo, commit_values(), revision['author'], revision_datetime(revision, 'revised_at'))
+    else:
+        to_update = dict()
+        last_revision = None
+        for revision in revisions:
+            to_update[revision['page_id']] = revision
+            last_revision = revision
 
-def download_html_page(page_id, html_repo_path, web_http_url):
-    r = requests.get("%s/show_by_id/%s" % (web_http_url, page_id))
-    page_path = html_repo_path / 'pages' / f'{page_id}.html'
-    page_path.write_bytes(r.content)
+        if last_revision:
+            updated = True
+            address_base = http_url + '/' + get_web_address(web_id) + '/show_by_id/'
+            for (page_id, revision) in to_update.items():
+                logger.info(f'Updating HTML for page {page_id}')
+                for (filename, content) in [
+                    ('content.html', download_page(address_base + page_id)),
+                    ('revision_id', str(revision['id'])),
+                    ('name', revision['name']),
+                ]:
+                    git_add_file(repo, Path('pages') / str(page_id) / filename, content)
 
-def download_and_stage_html_pages(pages_list, html_repo, html_repo_path, web_http_url):
-    for p in pages_list:
-        download_html_page(p, html_repo_path, web_http_url)
-    html_repo.stage(map(lambda p: "pages/%d.html" % p, pages_list))
+            def commit_values():
+                yield from commit_values_position_encode(revision_position(last_revision))
+                yield ('Comment', f'updated {len(to_update)} pages')
 
-def html_repo_populate(repo_path, html_repo_path, web_http_url, latest_download_file):
-    """
-    This is meant to be used in case the usual repository is already set up, and
-    but the html repository is not.    It will download the latest html version of
-    each page and save them all to the html repository as one commit.    It will
-    ignore pages that already have html versions downloaded.
-    """
-    write_latest_download_file(latest_download_file)
-    pages_list = map(lambda f: f[:-3], filter(
-        lambda f: (f.endswith(".md") and not os.path.isfile(os.path.join(html_repo_path, "pages", "%s.html" % f[:-3]))),
-        os.listdir(os.path.join(repo_path, "pages")),
-    ))
-    html_repo = dulwich.repo.Repo(html_repo_path)
-    download_and_stage_html_pages(pages_list, html_repo, html_repo_path, web_http_url)
-    html_repo.do_commit("Added current html versions.", "instiki2git <>")
+            git_commit(repo, commit_values(), time_before_query)
 
-def html_repo_update(html_repo_path, cursor, web_id, web_http_url, latest_download_file):
-    latest_download_time = read_latest_download_file(latest_download_file)
-    write_latest_download_file(latest_download_file)
-    revs = load_new_revisions_by_time(cursor, web_id, latest_download_time)
-    pages_list = {r["page_id"] for r in revs}
-    if pages_list:
-        html_repo = dulwich.repo.Repo(html_repo_path)
-        download_and_stage_html_pages(pages_list, html_repo, html_repo_path, web_http_url)
-        html_repo.do_commit("Updated %d pages." % len(pages_list), "instiki2git <>")
+    if updated:
+        logger.info('Pushing repository.')
+        dulwich.porcelain.push(repo = repo)
 
-# end html repository functions
-
-def cli():
+# Command-line interface
+def cli() -> NoReturn:
     parser = argparse.ArgumentParser(
         description = 'A tool for exporting an Instiki installation to a git repository.',
         add_help = False,
     )
+    parser.add_argument('--repo', type = Path, metavar = 'DIR', default = Path(), help = '''
+defaults to working directory
+''')
     parser.add_argument('--web-id', type = int, metavar = 'ID', required = True, help = 'ID of the web to back up')
     parser.add_argument('--html', action = 'store_true', help = 'back up html instead of source')
     parser.add_argument('--include-ip', action = 'store_true', help = '''
-include author IP in commit message for revisions
+Include author IP in the commit message for each revision.
+Source mode only.
 ''')
 
     g = parser.add_argument_group(title = 'HTML backup options')
-    g.add_argument('--populate', action = 'store_true', help = '''
-Populate HTML repository instead of updating it.
-This uses the source repository.
-''')
-    g.add_argument('--repo-html', type = Path, metavar = 'DIR')
-    g.add_argument('--latest-download-file', metavar = 'FILE', type = Path, help = '''
-File containing the time of the last HTML download.
-''')
-    g.add_argument('--http-url', type = str, metavar = 'URL', help = '''
-URL prefix to use for html backup.
-Example: https://ncatlab.org/nlab
+    g.add_argument('--http-url', type = str, metavar = 'URL', default = 'http://localhost', help = '''
+Base URL for downloading pages.
+HTML mode only.
+Defaults to http://localhost.
 ''')
 
     g = parser.add_argument_group(title = 'horizon options')
@@ -278,9 +319,6 @@ This helps prevent missing revisions that arrive out of order in the database or
     Only consider revisions older than the given UTC timestamp.
     Overrides `--safety-interval`.
 ''')
-
-    g = parser.add_argument_group(title = 'repository options')
-    g.add_argument('--repo', type = Path, metavar = 'DIR', required = True, help = 'required')
 
     g = parser.add_argument_group(title = 'database connection')
     g.add_argument('--host', type = str)
@@ -307,17 +345,17 @@ Print informational (specify once) or debug (specify twice) messages on stderr.
     }.get(args.verbose, logging.DEBUG))
 
     # Compute horizon.
-    horizon = {
-        True: datetime.utcfromtimestamp(args.horizon),
-        False: datetime.now() - timedelta(minutes = args.safety_interval),
-    }[args.horizon is not None]
+    if args.horizon is not None:
+        horizon = datetime.utcfromtimestamp(args.horizon)
+    else:
+        horizon = datetime.now() - timedelta(minutes = args.safety_interval)
     logger.debug(f'Horizon: {horizon}')
 
     logger.info('Reading repository.')
     repo = dulwich.repo.Repo(args.repo)
 
     logger.info('Connecting to database.')
-    connection = pymysql.connect(
+    connection: pymysql.Connection = pymysql.connect(
         host = args.host,
         port = args.port,
         unix_socket = args.unix_socket,
@@ -328,21 +366,14 @@ Print informational (specify once) or debug (specify twice) messages on stderr.
         charset = 'utf8',
         use_unicode = True,
     )
-    cursor = connection.cursor()
+    cursor: pymysql.cursors.DictCursorMixin = connection.cursor()
 
-    if not args.html:
-        load_and_commit_new_revisions(
-            repo,
-            cursor,
-            args.web_id,
-            horizon = horizon,
-            include_ip = args.include_ip,
-        )
-
-        logger.info('Pushing repository.')
-        dulwich.porcelain.push(repo = repo)
-    else:
-        if args.populate:
-            html_repo_populate(args.repo, args.html_repo, args.http_url, args.latest_download_file)
-        else:
-            html_repo_update(args.html_repo, cursor, args.web_id, args.http_url, args.latest_download_file)
+    load_commit_and_push(
+        repo,
+        cursor,
+        args.web_id,
+        horizon = horizon,
+        include_ip = args.include_ip,
+        http_url = args.http_url,
+        html_mode = args.html
+    )

--- a/src/cli.py
+++ b/src/cli.py
@@ -293,13 +293,11 @@ def read_config(config_file):
     "user": config_parser.get("database", "user"),
     "password": config_parser.get("database", "password"),
     "charset": config_parser.get("database", "charset")}
-  web_id = config_parser.get("web", "id")
   web_http_url = config_parser.get("web", "http_url")
   return {
     "repo_path": repo_path,
     "html_repo_path": html_repo_path,
     "db_config": db_config,
-    "web_id": web_id,
     "web_http_url": web_http_url}
 
 def setup_logging(verbose):
@@ -314,10 +312,11 @@ def setup_logging(verbose):
   type=click.Path(exists = True, path_type = Path),
   default=os.path.expanduser("~/.instiki2git"),
   help="Path to configuration file.")
+@click.option('-w', '--web-id', type = int, required = True)
 @click.option('--safety-interval', type = int, default = 300, show_default = True)
 @click.option('--include-ip', is_flag = True)
 @click.option('-v', '--verbose', count = True)
-def cli(config_file, safety_interval, include_ip, verbose):
+def cli(config_file, web_id, safety_interval, include_ip, verbose):
   setup_logging(verbose)
   logger.debug(f'Safety interval (in seconds): {safety_interval}')
   logger.debug(f'Include IPs: {include_ip}')
@@ -326,7 +325,6 @@ def cli(config_file, safety_interval, include_ip, verbose):
   config = read_config(config_file)
   repo_path = os.path.abspath(config["repo_path"])
   db_config = config["db_config"]
-  web_id = config["web_id"]
 
   logger.info('Reading repository.')
   repo = dulwich.repo.Repo(repo_path)
@@ -351,6 +349,7 @@ def cli(config_file, safety_interval, include_ip, verbose):
   type=click.Path(exists = True, path_type = Path),
   default=Path('~/.instiki2git').expanduser(),
   help="Path to configuration file.")
+@click.option('-w', '--web-id', type = int, required = True)
 @click.option("--latest-download-file",
   type=click.Path(path_type = Path),
   default=Path('/tmp/instiki2git-html'),
@@ -360,14 +359,13 @@ def cli(config_file, safety_interval, include_ip, verbose):
   default=False,
   help="Run in populate mode")
 @click.option('-v', '--verbose', count = True)
-def cli_html(config_file, latest_download_file, populate, verbose):
+def cli_html(config_file, web_id, latest_download_file, populate, verbose):
   setup_logging(verbose)
 
   config = read_config(config_file)
   repo_path = os.path.abspath(config["repo_path"])
   html_repo_path = os.path.abspath(config["html_repo_path"])
   db_config = config["db_config"]
-  web_id = config["web_id"]
   web_http_url = config["web_http_url"]
   if web_http_url.endswith("/"):
     web_http_url = web_http_url[:-1]

--- a/src/cli.py
+++ b/src/cli.py
@@ -13,7 +13,7 @@ from instiki2git.percent_code import PercentCode
 
 logger: logging.Logger = logging.getLogger(__name__)
 
-# Database queries
+# Database queries.
 
 def query_iterator(
     cursor: pymysql.cursors.DictCursorMixin,
@@ -167,9 +167,9 @@ def revision_position(revision: dict[str, Any]) -> Position:
 def get_web_address(cursor: pymysql.cursors.DictCursorMixin, web_id: int) -> str:
     return query_singleton(cursor, 'select address from webs where id = %s', (web_id,))['address']
 
-def download_page(url: str) -> bytes:
+def download_page(session: requests.Session, url: str) -> bytes:
     logger.debug(f'Loading {url}.')
-    return requests.get(url).content
+    return session.get(url).content
 
 # Main work function.
 def load_commit_and_push(
@@ -270,11 +270,12 @@ where idx.web_id = %s\
 
         if last_revision:
             updated = True
+            session = requests.Session()
             address_base = http_url + '/' + get_web_address(web_id) + '/show_by_id/'
             for (page_id, revision) in to_update.items():
                 logger.info(f'Updating HTML for page {page_id}')
                 for (filename, content) in [
-                    ('content.html', download_page(address_base + page_id)),
+                    ('content.html', download_page(session, address_base + page_id)),
                     ('revision_id', str(revision['id'])),
                     ('name', revision['name']),
                 ]:
@@ -290,7 +291,7 @@ where idx.web_id = %s\
         logger.info('Pushing repository.')
         dulwich.porcelain.push(repo = repo)
 
-# Command-line interface
+# Command-line interface.
 def cli() -> NoReturn:
     parser = argparse.ArgumentParser(
         description = 'A tool for exporting an Instiki installation to a git repository.',

--- a/src/cli.py
+++ b/src/cli.py
@@ -128,9 +128,9 @@ def commit_revision(repo: dulwich.repo.Repo, revision: dict):
   id = revision['id']
   logger.info(f'Committing revision {id}.')
 
-  page_id = revision['page_id']
-  add_file(repo, Path('pages') / f'{page_id}.md', revision['content'])
-  add_file(repo, Path('pages') / f'{page_id}.meta', commit_message_encode({'Name': revision['name']}))
+  path = Path('pages') / str(revision['page_id'])
+  add_file(repo, path / 'content.md', revision['content'])
+  add_file(repo, path / 'name', revision['name'])
 
   # git insists on an email address, so we add an empty one.
   def with_empty_email(xs):

--- a/src/cli.py
+++ b/src/cli.py
@@ -319,6 +319,9 @@ def setup_logging(verbose):
 @click.option('-v', '--verbose', count = True)
 def cli(config_file, safety_interval, include_ip, verbose):
   setup_logging(verbose)
+  logger.debug(f'Safety interval (in seconds): {safety_interval}')
+  logger.debug(f'Include IPs: {include_ip}')
+  logger.debug(f'Verbosity level: {verbose}')
 
   config = read_config(config_file)
   repo_path = os.path.abspath(config["repo_path"])

--- a/src/cli.py
+++ b/src/cli.py
@@ -307,7 +307,7 @@ def cli() -> NoReturn:
         add_help = False,
     )
     parser.add_argument('--repo', type = Path, metavar = 'DIR', default = Path(), help = '''
-Path to a git repository that source revisions or HTML renderings should be comitted to.
+Path to a git repository (may be bare) that source revisions or HTML renderings should be comitted to.
 This repository must be on a branch with a default push remote set up.
 For an initial run, the current commit must have message starting with 'initial commit' (up to capitalization).
 Defaults to working directory.
@@ -382,7 +382,7 @@ Print informational (specify once) or debug (specify twice) messages on stderr.
 
     logger.info('Reading repository.')
     logger.debug(f'Repository path: {args.repo}')
-    repo = dulwich.repo.Repo(args.repo)
+    repo = dulwich.repo.Repo(str(args.repo))
 
     logger.info('Connecting to database.')
     connection: pymysql.Connection = pymysql.connect(

--- a/src/cli.py
+++ b/src/cli.py
@@ -287,11 +287,10 @@ def read_config(config_file):
   config_parser.read(config_file)
   repo_path = config_parser.get("repository", "path")
   html_repo_path = config_parser.get("html_repository", "path")
-  web_http_url = config_parser.get("web", "http_url")
   return {
     "repo_path": repo_path,
     "html_repo_path": html_repo_path,
-    "web_http_url": web_http_url}
+  }
 
 def setup_logging(verbose):
   logging.basicConfig()
@@ -366,6 +365,7 @@ def cli(config_file, host, port, unix_socket, user, password, database, web_id, 
 @click.option('-p', '--password', type = str)
 @click.option('-d', '--database', type = str, required = True)
 @click.option('-w', '--web-id', type = int, required = True)
+@click.option('-W', '--web-http-url', type = str, required = True)
 @click.option("--latest-download-file",
   type=click.Path(path_type = Path),
   default=Path('/tmp/instiki2git-html'),
@@ -375,7 +375,7 @@ def cli(config_file, host, port, unix_socket, user, password, database, web_id, 
   default=False,
   help="Run in populate mode")
 @click.option('-v', '--verbose', count = True)
-def cli_html(config_file, host, port, unix_socket, user, password, database, web_id, latest_download_file, populate, verbose):
+def cli_html(config_file, host, port, unix_socket, user, password, database, web_id, web_http_url, latest_download_file, populate, verbose):
   setup_logging(verbose)
 
   config = read_config(config_file)
@@ -389,7 +389,6 @@ def cli_html(config_file, host, port, unix_socket, user, password, database, web
     'password': password,
     'database': database,
   }
-  web_http_url = config["web_http_url"]
   if web_http_url.endswith("/"):
     web_http_url = web_http_url[:-1]
   if populate:

--- a/src/cli.py
+++ b/src/cli.py
@@ -81,32 +81,28 @@ def commit_values_position_decode(values: dict[str, str]) -> Position:
 
 # git functions.
 
-def get_head(repo: dulwich.repo.Repo) -> Optional[bytes]:
-    try:
-        return repo.head()
-    except KeyError:
-        return None
-
-def get_commit(repo: dulwich.repo.Repo, sha: bytes) -> dulwich.repo.Commit:
-    sha_file: dulwich.objects.ShaFile = repo.get_object(sha)
-    if not isinstance(sha_file, dulwich.repo.Commit):
+def get_commit(repo: dulwich.repo.Repo, id: bytes) -> dulwich.repo.Commit:
+    obj: dulwich.objects.ShaFile = repo.get_object(id)
+    if not isinstance(obj, dulwich.repo.Commit):
         raise TypeError('does not refer to a commit: {sha.decode()}')
-    return sha_file
+    return obj
 
 def git_add_file(repo: dulwich.repo.Repo, path: Path, content: bytes | str) -> NoReturn:
     """
     Create a file in the given repository and stage it.
     This creates all needed parent directories.
 
-    Note: the given path must be relative to the repository path.
+    The given path must be relative and not contain any segments '.' or '..'.
+    It is interpreted relative to the repository path.
     """
+    logger.debug(f'Adding file at {path}.')
     for ancestor in reversed(path.parents):
-        ancestor.mkdir(exist_ok = True)
+        (repo.path / ancestor).mkdir(exist_ok = True)
 
     if isinstance(content, str):
-        path.write_text(content, encoding = 'utf8')
+        (repo.path / path).write_text(content, encoding = 'utf8')
     else:
-        path.write_bytes(content)
+        (repo.path / path).write_bytes(content)
 
     repo.stage(path)
 
@@ -130,6 +126,7 @@ def git_commit(
     The message is formed by encoding the given commit values.
     An optional author (without email) can be given.
     """
+    logger.debug('Committing.')
     repo.do_commit(
         message = commit_message_encode(dict(commit_values)),
         committer = git_script_identity,
@@ -142,13 +139,14 @@ def git_commit(
 def get_current_position(repo: dulwich.repo.Repo) -> Optional[Position]:
     """
     Return the tuple of (updated_at, id) for the revision encoded by the head commit.
-    Returns None if there is no head (e.g. if the repository is empty).
+    Returns None if the head commit is the initial commit.
     """
-    ref: bytes = get_head(repo)
-    if ref:
-        commit: dulwich.objects.Commit = get_commit(repo, ref)
-        commit_values: dict[str, str] = commit_message_decode(commit.message)
-        return commit_values_position_decode(commit_values)
+    commit: dulwich.repo.Commit = repo.get_object(repo.head())
+    if commit.message.lower().startswith(b'initial commit'):
+        return None
+
+    commit_values: dict[str, str] = commit_message_decode(commit.message)
+    return commit_values_position_decode(commit_values)
 
 # Revision functions.
 
@@ -171,15 +169,32 @@ def download_page(session: requests.Session, url: str) -> bytes:
     logger.debug(f'Loading {url}.')
     return session.get(url).content
 
+def partition_id(sizes: Iterable[int], id) -> list[Path]:
+    """
+    Partition the decimal representation of the given id into a relative path.
+    The given sizes control how many digits are used for each segment, starting with the least significant.
+
+    Example:
+        partition_id([2, 3], 4567) = Path() / '67' / '045'.
+    """
+    def f() -> Iterable[str]:
+        nonlocal id
+        for size in sizes:
+            (id, key) = divmod(id, pow(10, size))
+            yield f'{key:0{size}}'
+
+    return Path().joinpath(*f())
+
 # Main work function.
 def load_commit_and_push(
     repo: dulwich.repo.Repo,
     cursor: pymysql.cursors.DictCursorMixin,
     web_id: int,
     horizon: Optional[datetime] = None,
+    partition_sizes: list[int] = list(),
+    html_mode: bool = False,
     include_ip: bool = False,
     http_url: str = None,
-    html_mode: bool = False,
 ) -> NoReturn:
     """
     Arguments:
@@ -194,15 +209,18 @@ def load_commit_and_push(
         If given, only consider revisions with prior update time (updated_at).
         This should be about a minute behind current time.
         This helps prevent missing revision updates with identical revision time.
+    * partition_sizes:
+        Partition pages into nested subdirectories.
+        See partition_id.
+    * html_mode:
+        Back up rendered HTML pages instead of sources.
+        Note: do note mix source and html repositories.
     * include_ip:
         Whether to include the author IP in the commit message for each revision.
         Only used in source mode.
     * http_url:
         URL prefix to use for html backup.
         Only used in HTML mode.
-    * html_mode:
-        Back up rendered HTML pages instead of sources.
-        Note: do note mix source and html repositories.
     """
     logger.debug('Resetting index.')
     repo.reset_index()
@@ -241,6 +259,10 @@ where idx.web_id = %s\
     query += ' order by idx.updated_at, idx.id'
     revisions = query_iterator(cursor, query, params)
 
+    def add_page_file(page_id, filename, content) -> NoReturn:
+        path = Path('pages') / partition_id(partition_sizes, page_id) / str(page_id) / filename
+        git_add_file(repo, path, content)
+
     updated = False
     if not html_mode:
         for revision in revisions:
@@ -252,7 +274,7 @@ where idx.web_id = %s\
                 ('content.md', revision['content']),
                 ('name', revision['name'])
             ]:
-                git_add_file(repo, Path('pages') / str(revision['page_id']) / filename, content)
+                add_page_file(revision['page_id'], filename, content)
 
             def commit_values():
                 yield from commit_values_position_encode(revision_position(revision))
@@ -279,7 +301,7 @@ where idx.web_id = %s\
                     ('revision_id', str(revision['id'])),
                     ('name', revision['name']),
                 ]:
-                    git_add_file(repo, Path('pages') / str(page_id) / filename, content)
+                    add_page_file(page_id, filename, content)
 
             def commit_values():
                 yield from commit_values_position_encode(revision_position(last_revision))
@@ -298,10 +320,25 @@ def cli() -> NoReturn:
         add_help = False,
     )
     parser.add_argument('--repo', type = Path, metavar = 'DIR', default = Path(), help = '''
+Path to a git repository that source revisions or HTML renderings should be comitted to.
+This repository must be on a branch with a default push remote set up.
+For an initial run, the current commit must have message starting with 'initial commit' (up to capitalization).
 Defaults to working directory.
 ''')
     parser.add_argument('--web-id', type = int, metavar = 'ID', required = True, help = 'ID of the web to back up.')
     parser.add_argument('--html', action = 'store_true', help = 'Back up HTML instead of source.')
+    parser.add_argument(
+        '--partition-sizes',
+        nargs = '*',
+        metavar = 'NUM_DIGITS',
+        type = int,
+        choices = range(1, 5),
+        default = [],
+        help = '''
+Partition pages into nested subdirectories.
+The given sizes define how many digits to use at each level, starting with the least significant.
+Example: --partition 2 3 stores page 4567 at pages/67/045/4567.
+''')
 
     g = parser.add_argument_group(title = 'source backup options')
     parser.add_argument('--include-ip', action = 'store_true', help = '''
@@ -357,6 +394,7 @@ Print informational (specify once) or debug (specify twice) messages on stderr.
     logger.debug(f'Horizon: {horizon}')
 
     logger.info('Reading repository.')
+    logger.debug(f'Repository path: {args.repo}')
     repo = dulwich.repo.Repo(args.repo)
 
     logger.info('Connecting to database.')
@@ -378,7 +416,8 @@ Print informational (specify once) or debug (specify twice) messages on stderr.
         cursor,
         args.web_id,
         horizon = horizon,
-        include_ip = args.include_ip,
+        partition_sizes = args.partition_sizes,
         http_url = args.http_url,
+        include_ip = args.include_ip,
         html_mode = args.html
     )

--- a/src/general.py
+++ b/src/general.py
@@ -13,3 +13,11 @@ def iter_inhabited(it: Iterator[T]) -> (bool, Iterator[T]):
     except StopIteration:
         return (False, tuple())
     return (True, itertools.chain((x,), it))
+
+def iter_to_maybe(it: Iterator[T]) -> Optional[T]:
+    try:
+        x = next(it)
+    except StopIteration:
+        return None
+    () = it
+    return x

--- a/src/general.py
+++ b/src/general.py
@@ -1,0 +1,15 @@
+import itertools
+from typing import Iterator, Optional, TypeVar
+
+T = TypeVar('T')
+
+def iter_inhabited(it: Iterator[T]) -> (bool, Iterator[T]):
+    """
+    Test whether an iterable is inhabited.
+    Since this modifies the original iterable, a replacement iterable is returned.
+    """
+    try:
+        x = next(it)
+    except StopIteration:
+        return (False, tuple())
+    return (True, itertools.chain((x,), it))

--- a/src/git_tools.py
+++ b/src/git_tools.py
@@ -1,0 +1,104 @@
+import dulwich.objects
+import dulwich.repo
+from pathlib import Path
+import stat
+from typing import Iterable, Optional, Tuple
+
+from instiki2git.percent_code import PercentCode
+
+
+def mode(obj: dulwich.objects.ShaFile) -> int:
+    if isinstance(obj, dulwich.objects.Tree):
+        return stat.S_IFDIR
+    if isinstance(obj, dulwich.objects.Blob):
+        return stat.S_IFREG | 0o644
+    raise TypeError('unexpected object')
+
+def path(p: Path) -> list[bytes]:
+    return [part.encode('utf8') for part in p.parts]
+
+def get_commit(repo: dulwich.repo.Repo, id: bytes) -> dulwich.repo.Commit:
+    obj: dulwich.objects.ShaFile = repo.get_object(id)
+    if not isinstance(obj, dulwich.repo.Commit):
+        raise TypeError('does not refer to a commit: {sha.decode()}')
+    return obj
+
+def add_blob(repo: dulwich.repo.Repo, content: bytes) -> dulwich.objects.Blob:
+    blob = dulwich.objects.Blob()
+    blob._set_data(content)
+    repo.object_store.add_object(blob)
+    return blob
+
+def add_tree(repo: dulwich.repo.Repo, entries: Iterable[Tuple[bytes, dulwich.objects.ShaFile]]) -> dulwich.objects.Tree:
+    tree = dulwich.objects.Tree()
+    for (name, obj) in entries:
+        tree[name] = (mode(obj), obj.id)
+    repo.object_store.add_object(tree)
+    return tree
+
+def add_flat_tree(repo: dulwich.repo.Repo, files: list[Tuple[bytes, bytes]]) -> dulwich.objects.Tree:
+    return add_tree(repo, ((name, add_blob(repo, content)) for (name, content) in files))
+
+def tree_get(
+    repo: dulwich.repo.Repo,
+    tree: dulwich.objects.Tree,
+    name: bytes,
+) -> Optional[dulwich.objects.ShaFile]:
+    """Get an entry from a tree, if it exists."""
+    if not name in tree:
+        return None
+    (_, id) = tree[name]
+    return repo.get_object(id)
+
+def tree_set(
+    repo: dulwich.repo.Repo,
+    tree: dulwich.objects.Tree,
+    name: bytes,
+    obj: dulwich.objects.ShaFile,
+) -> dulwich.objects.Tree:
+    """
+    Set an entry in a tree.
+    The new tree is added to the object store of the given repository.
+    Returns the new tree.
+    """
+    tree[name] = (mode(obj), obj.id)
+    repo.object_store.add_object(tree)
+    return tree
+
+def tree_replace_nested(
+    repo: dulwich.repo.Repo,
+    tree: Optional[dulwich.objects.ShaFile],
+    path: list[bytes],
+    obj: dulwich.objects.ShaFile,
+) -> dulwich.objects.ShaFile:
+    """
+    Replace a nested entry in a nested tree.
+    If no nested tree is given, it is freshly created.
+    All objects created during this are added to the object store of the repository.
+    """
+    def f(tree: Optional[dulwich.objects.Tree], i: int):
+        if i == len(path):
+            return obj
+
+        # Now we assume that tree has type Optional[dulwich.objects.Tree].
+        if tree is None:
+            tree = dulwich.objects.Tree()
+
+        name = path[i]
+        sub = tree_get(repo, tree, name)
+        sub = f(sub, i + 1)
+        return tree_set(repo, tree, name, sub)
+
+    return f(tree, 0)
+
+# These are the reserved bytes in git commit authors and committers.
+identity_code = PercentCode(reserved = map(ord, ['\0', '\n', '<', '>']))
+
+def identity_with_empty_email(name: bytes) -> bytes:
+    """Format a git user identity without an email address."""
+    return name + b' <>'
+
+
+#r = dulwich.repo.Repo('/home/noname/git-test')
+#add_blob(r, b'123')
+#add_flat_tree(r, [(b'a', b'123'), (b'b', b'qwe')])

--- a/src/percent_code.py
+++ b/src/percent_code.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 class PercentCode:
     '''Percent coding operating on bytes.'''
 
-    def __init__(self, *, special : int = ord('%'), reserved: Iterable[int] = []):
+    def __init__(self, *, special: int = ord('%'), reserved: Iterable[int] = []):
         self.special = special
         self.to_encode = frozenset([special] + list(reserved))
 

--- a/src/percent_code.py
+++ b/src/percent_code.py
@@ -36,10 +36,3 @@ class PercentCode:
 
     def encode(self, xs: Iterable[int]) -> bytes:
         return bytes(self.encode_iterable(xs))
-
-# These are the reserved bytes in git commit authors and committers.
-git_identity = PercentCode(reserved = map(ord, ['\0', '\n', '<', '>']))
-
-# These are the reserved bytes in our commit metadata.
-commit_data_key = PercentCode(reserved = map(ord, ['\0', '\n', ':']))
-commit_data_value = PercentCode(reserved = map(ord, ['\0', '\n']))


### PR DESCRIPTION
Escaping characters as per #7.

We should use a similar encoding for page titles, escaping at least '\n' (and perhaps '\0'). 